### PR TITLE
Adjust Dependabot and Spotless versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
   - package-ecosystem: "gradle" # See documentation for possible values
     directories:
       - "/api-genshin-impact"
@@ -19,10 +20,10 @@ updates:
       - "lib-mrlonis-types"
       - "playground"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     groups:
       production-version-updates:
         applies-to: version-updates

--- a/buildSrc/src/main/groovy/mrlonis-java-library.gradle
+++ b/buildSrc/src/main/groovy/mrlonis-java-library.gradle
@@ -43,11 +43,11 @@ tasks.withType(JavaCompile).configureEach {
 
 spotless {
     java {
-        cleanthat().version('2.20')
+        cleanthat().version('2.25')
                 .sourceCompatibility('21')
                 .addMutator('SafeAndConsensual')
                 .addMutator('SafeButNotConsensual')
-        palantirJavaFormat('2.50.0').style('PALANTIR').formatJavadoc(true)
+        palantirJavaFormat('2.94.0').style('PALANTIR').formatJavadoc(true)
         formatAnnotations()
         removeUnusedImports()
         importOrder()

--- a/buildSrc/src/main/groovy/mrlonis-java-spring-boot.gradle
+++ b/buildSrc/src/main/groovy/mrlonis-java-spring-boot.gradle
@@ -64,11 +64,11 @@ tasks.register('restartDocker') {
 
 spotless {
     java {
-        cleanthat().version('2.20')
+        cleanthat().version('2.25')
                 .sourceCompatibility('21')
                 .addMutator('SafeAndConsensual')
                 .addMutator('SafeButNotConsensual')
-        palantirJavaFormat('2.50.0').style('PALANTIR').formatJavadoc(true)
+        palantirJavaFormat('2.94.0').style('PALANTIR').formatJavadoc(true)
         formatAnnotations()
         removeUnusedImports()
         importOrder()


### PR DESCRIPTION
Switch Dependabot checks for GitHub Actions and Gradle from weekly to monthly and cap open update PRs at 5 to reduce PR churn. Update Spotless Java tooling in shared Gradle scripts by bumping Cleanthat (2.20 -> 2.25) and Palantir Java Format (2.50.0 -> 2.94.0).